### PR TITLE
New Option to mirror only updated value

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,5 +143,5 @@ Permission to modify and redistribute is granted under the terms of the Apache 2
 
   [License]: https://github.com/stevespringett/vulndb-data-mirror/blob/master/LICENSE
   [Pre-compiled binaries]: https://github.com/stevespringett/vulndb-data-mirror/releases
-  [VulnDB]: https://vulndb.cyberriskanalytics.com/
+  [VulnDB]: https://vulndb.flashpoint.io/
   [Risk Based Security]: https://www.riskbasedsecurity.com/ 

--- a/src/main/java/us/springett/vulndbdatamirror/client/VulnDbApi.java
+++ b/src/main/java/us/springett/vulndbdatamirror/client/VulnDbApi.java
@@ -53,6 +53,8 @@ public class VulnDbApi {
     private static final String VULNERABILITIES_URL = "https://vulndb.flashpoint.io/api/v1/vulnerabilities/"
             + "?nested=true&additional_info=true&show_cpe_full=true&show_cvss_v3=true&package_info=true&vtem=true";
     private static final String VULNERABILITIES_FIND_BY_CPE_URL = "https://vulndb.flashpoint.io/api/v1/vulnerabilities/find_by_cpe?&cpe=";
+    //Returns vulnerabilities that were updated or created in the last specified number of hours.
+    private static final String VULNERABILITIES_LAST_UPDATED = "https://vulndb.flashpoint.io/api/v1/vulnerabilities/find_by_time_full?hours_ago=";
 
     private final UnirestInstance ui;
     private final String consumerKey;
@@ -162,6 +164,20 @@ public class VulnDbApi {
             LOGGER.error("An error occurred while URL encoding a CPE", e);
         }
         return getResults(VULNERABILITIES_FIND_BY_CPE_URL + encodedCpe, Vulnerability.class, size, page);
+    }
+
+    /**
+     * Makes a request and returns Last Updated {@link Vulnerability} Results.
+     * Includes the following options preset for ease of use and performance improvements:
+     * nested=true, additional_info=true, show_cpe_full=true, full_reference_url=true, show_cvss_v3=true, package_info=true, and library_info=true
+     * @param size the number of items to fetch
+     * @param page the page number of the fetched items
+     * @param hours_ago The number of hours far back you want to check for updated vulnerabilities
+     * @return a Results object
+     * @since 1.0.0
+     */
+    public Results getUpdatedVulnerabilities(final int size, final int page, final int hours_ago) {
+        return getResults(VULNERABILITIES_LAST_UPDATED + hours_ago, Vulnerability.class, size, page);
     }
 
     /**

--- a/src/main/java/us/springett/vulndbdatamirror/client/VulnDbApi.java
+++ b/src/main/java/us/springett/vulndbdatamirror/client/VulnDbApi.java
@@ -37,7 +37,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
 /**
- * OAuth access to the VulnDB API. For more information visit https://vulndb.cyberriskanalytics.com/ .
+ * OAuth access to the VulnDB API. For more information visit https://vulndb.flashpoint.io/ .
  *
  * @author Steve Springett
  * @since 1.0.0
@@ -46,13 +46,13 @@ public class VulnDbApi {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(VulnDbApi.class);
     private static final String USER_AGENT = "VulnDB Data Mirror (https://github.com/stevespringett/vulndb-data-mirror)";
-    private static final String STATUS_URL = "https://vulndb.cyberriskanalytics.com/api/v1/account_status";
-    private static final String VENDORS_URL = "https://vulndb.cyberriskanalytics.com/api/v1/vendors/";
-    private static final String PRODUCTS_URL = "https://vulndb.cyberriskanalytics.com/api/v1/products/";
-    private static final String VERSIONS_URL = "https://vulndb.cyberriskanalytics.com/api/v1/versions/by_product_id?product_id=";
-    private static final String VULNERABILITIES_URL = "https://vulndb.cyberriskanalytics.com/api/v1/vulnerabilities/"
+    private static final String STATUS_URL = "https://vulndb.flashpoint.io/api/v1/account_status";
+    private static final String VENDORS_URL = "https://vulndb.flashpoint.io/api/v1/vendors/";
+    private static final String PRODUCTS_URL = "https://vulndb.flashpoint.io/api/v1/products/";
+    private static final String VERSIONS_URL = "https://vulndb.flashpoint.io/api/v1/versions/by_product_id?product_id=";
+    private static final String VULNERABILITIES_URL = "https://vulndb.flashpoint.io/api/v1/vulnerabilities/"
             + "?nested=true&additional_info=true&show_cpe_full=true&show_cvss_v3=true&package_info=true&vtem=true";
-    private static final String VULNERABILITIES_FIND_BY_CPE_URL = "https://vulndb.cyberriskanalytics.com/api/v1/vulnerabilities/find_by_cpe?&cpe=";
+    private static final String VULNERABILITIES_FIND_BY_CPE_URL = "https://vulndb.flashpoint.io/api/v1/vulnerabilities/find_by_cpe?&cpe=";
 
     private final UnirestInstance ui;
     private final String consumerKey;


### PR DESCRIPTION
This pull request adds a new API endpoint https://vulndb.flashpoint.io/api/v1/vulnerabilities/find_by_time_full?hours_ago=?hour to retrieve the last updated vulnerabilities within a given time range. 

This will make it easier to synchronize only the updated vulnerabilities and reduce the number of required operational tasks.