### PR TITLE
Implement Secure OAuth2 Authentication for Enhanced API Access

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,13 +124,6 @@
             <version>${lib.unirest.version}</version>
             <scope>compile</scope>
         </dependency>
-        <!-- OAuth 1.0a Signing Request -->
-        <dependency>
-            <groupId>oauth.signpost</groupId>
-            <artifactId>signpost-core</artifactId>
-            <version>${lib.signpost-core.version}</version>
-            <scope>compile</scope>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
In response to the recent API URL change, it has become mandatory to incorporate OAuth2 authentication. To align with Vulndb's recommendations and ensure a secure connection, we have implemented the retrieval of an access token using our client credentials and secret.

Considering that HTTPS handles URL signing automatically, there is no need for explicit URL signing in this implementation. The security aspects are effectively managed by the HTTPS protocol.

Additionally, we have retained the inclusion of a User Agent in our GET request to provide comprehensive information about our VulnDB Data Mirror application.

I am not sure if I should remove the oauth signpost references in pom.xml https://github.com/stevespringett/vulndb-data-mirror/blob/d65c619002e4bc96127ca86c51edfd61b53a4798/pom.xml#L129