### PR TITLE
New Feature: Download VulnDB Vulnerabilities Without NVD Matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ usage: vulndb-data-mirror
  -vend,--mirror-vendors           Mirror the vendors data feed
  -vuln,--mirror-vulnerabilities   Mirror the vulnerabilities data feed
  -stat,--status-only              Displays VulnDB API status only
+ -u,--mirror-update <hours>       Mirror just the updated vulnerabilities data feed from the past <hours>
+ -n, --no-nvd-additional          Filters vulnerabilities to download only those without additional information from the NVD.
+                                  **Note:** This option only works when used with `--mirror-vulnerabilities`.
 ```
 
 ### Mirror Recovery

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,12 @@
             <version>${lib.unirest.version}</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.15.2</version> <!-- Use the latest stable version -->
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/us/springett/vulndbdatamirror/VulnDbDataMirror.java
+++ b/src/main/java/us/springett/vulndbdatamirror/VulnDbDataMirror.java
@@ -114,7 +114,7 @@ public class VulnDbDataMirror {
                 final int hours = Integer.parseInt(line.getOptionValue("mirror-update"));
                 mirror.mirrorUpdatedVulnerabilities(hours);
             }
-            if (!(line.hasOption("mirror-vendors") && line.hasOption("mirror-products") && line.hasOption("mirror-vulnerabilities"))) {
+            if (!(line.hasOption("mirror-vendors") || line.hasOption("mirror-products") || line.hasOption("mirror-vulnerabilities"))) {
                 System.out.println("A feed to mirror was not specified. Defaulting to mirror all feeds.");
                 mirror.mirrorVendors();
                 mirror.mirrorProducts();

--- a/src/main/java/us/springett/vulndbdatamirror/client/VulnDbApi.java
+++ b/src/main/java/us/springett/vulndbdatamirror/client/VulnDbApi.java
@@ -62,7 +62,8 @@ public class VulnDbApi {
     public enum Type {
         VENDORS,
         PRODUCTS,
-        VULNERABILITIES
+        VULNERABILITIES,
+        VULNERABILITIES_FILTERED
     }
 
     public VulnDbApi(final String consumerKey, final String consumerSecret) {


### PR DESCRIPTION
Feature: 
- Adds the --mirror-vulnerabilities --no-nvd-additional option to filter and download vulnerabilities from VulnDB that do not have corresponding NVD entries.
- Addressing gaps in NVD reports.
- Implements filtering using the nvd_additional_information property, verifying that the array size is 0.

Why this is important:
We are implementing this to specifically target gaps in NVD reports. Vulnerabilities from VulnDB that are not matched to a CVE provide additional and valuable information, helping us fill in areas where NVD reports may be incomplete or lacking.

Fix: Correct Logical Condition for Default Feed Mirroring

Resolves an issue where specifying only one mirroring option (--mirror-vendors, --mirror-products, or --mirror-vulnerabilities) incorrectly triggered the default behavior of mirroring all feeds.
Updates the condition to use || (OR), ensuring default mirroring occurs only when none of the options are specified.